### PR TITLE
Filter out newlines from the template

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -152,6 +152,7 @@ export class ConfigTemplateCard extends LitElement {
       }
     }
 
+    template = template.replace(/\n/g, "")
     return eval(template.substring(2, template.length - 1));
   }
 }

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -152,7 +152,7 @@ export class ConfigTemplateCard extends LitElement {
       }
     }
 
-    template = template.replace(/\n/g, "")
+    template = template.replace(/\n/g, '');
     return eval(template.substring(2, template.length - 1));
   }
 }


### PR DESCRIPTION
When building a complex yaml template you cannot indent the "javascript" because the YAML parser inserts newlines and `eval` doesn't seem to work with strings with newlines in it (in my testing anyways).