### PR TITLE
Improved Performance and Memory Usage

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -25,6 +25,8 @@ export class ConfigTemplateCard extends LitElement {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @internalProperty() private _config?: ConfigTemplateConfig;
   @internalProperty() private _helpers?: any;
+  private _variables = '';
+  private _vars?: any[] | { [key: string]: any };
   private _initialized = false;
 
   public setConfig(config: ConfigTemplateConfig): void {
@@ -49,8 +51,36 @@ export class ConfigTemplateCard extends LitElement {
     }
 
     this._config = config;
-
+    this.prepareVariablesString();
     this.loadCardHelpers();
+  }
+
+  private prepareVariablesString(): void {
+    let vars: any[] | { [key: string]: any } | undefined = void 0;
+    let varDef = '';
+
+    if (this._config) {
+      if (Array.isArray(this._config.variables)) {
+        // if variables are an array, create vars as an array
+        vars = [];
+        for (const v in this._config.variables) {
+          const newV = eval(this._config.variables[v]);
+          vars.push(newV);
+        }
+      } else {
+        // if it is an object, then create a key-value map containing
+        // the values
+        vars = {};
+        for (const varName in this._config.variables) {
+          const newV = eval(this._config.variables[varName]);
+          vars[varName] = newV;
+          // create variable definitions to be injected:
+          varDef = varDef + `var ${varName} = vars['${varName}'];\n`;
+        }
+      }
+    }
+    this._vars = vars;
+    this._variables = varDef;
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -68,12 +98,12 @@ export class ConfigTemplateCard extends LitElement {
       if (oldHass) {
         let changed = false;
         this._config.entities.forEach(entity => {
-          changed =
-            changed ||
-            Boolean(
-              this.hass &&
-                oldHass.states[this._evaluateTemplate(entity)] !== this.hass.states[this._evaluateTemplate(entity)],
-            );
+          if (!changed) {
+            const evaluatedTemplate = this._evaluateTemplate(entity);
+            changed =
+              changed ||
+              Boolean(this.hass && oldHass.states[evaluatedTemplate] !== this.hass.states[evaluatedTemplate]);
+          }
         });
 
         return changed;
@@ -165,32 +195,12 @@ export class ConfigTemplateCard extends LitElement {
       return template;
     }
 
+    // user, states and vars might be used in the eval context
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const user = this.hass ? this.hass.user : undefined;
     const states = this.hass ? this.hass.states : undefined;
-    let vars: any[] | { [key: string]: any };
-    let varDef = '';
+    const vars = this._vars;
 
-    if (this._config) {
-      if (Array.isArray(this._config.variables)) {
-        // if variables are an array, create vars as an array
-        vars = [];
-        for (const v in this._config.variables) {
-          const newV = eval(this._config.variables[v]);
-          vars.push(newV);
-        }
-      } else {
-        // if it is an object, then create a key-value map containing
-        // the values
-        vars = {};
-        for (const varName in this._config.variables) {
-          const newV = eval(this._config.variables[varName]);
-          vars[varName] = newV;
-          // create variable definitions to be injected:
-          varDef = varDef + `var ${varName} = vars['${varName}'];\n`;
-        }
-      }
-    }
-    return eval(varDef + template.substring(2, template.length - 1));
+    return eval(this._variables + template.substring(2, template.length - 1));
   }
 }

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -96,17 +96,13 @@ export class ConfigTemplateCard extends LitElement {
       const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
 
       if (oldHass) {
-        let changed = false;
-        this._config.entities.forEach(entity => {
-          if (!changed) {
-            const evaluatedTemplate = this._evaluateTemplate(entity);
-            changed =
-              changed ||
-              Boolean(this.hass && oldHass.states[evaluatedTemplate] !== this.hass.states[evaluatedTemplate]);
+        for (const entity of this._config.entities) {
+          const evaluatedTemplate = this._evaluateTemplate(entity);
+          if (Boolean(this.hass && oldHass.states[evaluatedTemplate] !== this.hass.states[evaluatedTemplate])) {
+            return true;
           }
-        });
-
-        return changed;
+        }
+        return false;
       }
     }
 


### PR DESCRIPTION
The variables part of the eval statement is always the same unless the config changes, so I changed the code to cache this part.
I have also changed the loop to evaluate the template only once instead of twice and allow for early returns.