### PR TITLE
Dashboard variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,22 @@ type: 'custom:config-template-card'
         name: '${ setTempMessage(currentTemp) }'
 ````
 
+## Dashboard wide variables
+
+If you need to use the same variable in multiple cards, then instead of defining it in each card's `variables` you can do that once for the entire dashboard.
+
+```yaml
+title: My dashboard
+
+config_template_card:
+  variables:
+    - states['sensor.light'].state
+
+views:
+```
+
+Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`. In the mixed mode, `vars` have array indices and as well as variable names.
+
 ### Note: All templates must be enclosed by `${}`
 
 [Troubleshooting](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)

--- a/README.md
+++ b/README.md
@@ -169,9 +169,8 @@ If you need to use the same variable in multiple cards, then instead of defining
 ```yaml
 title: My dashboard
 
-config_template_card:
-  variables:
-    - states['sensor.light'].state
+config_template_card_vars:
+  - states['sensor.light'].state
 
 views:
 ```

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -68,8 +68,8 @@ export class ConfigTemplateCard extends LitElement {
   private getLovelaceConfig() {
     const panel = this.getLovelacePanel() as any;
 
-    if (panel && panel.lovelace && panel.lovelace.config && panel.lovelace.config.config_template_card) {
-      return panel.lovelace.config.config_template_card
+    if (panel && panel.lovelace && panel.lovelace.config && panel.lovelace.config.config_template_card_vars) {
+      return panel.lovelace.config.config_template_card_vars
     }
 
     return {}
@@ -231,7 +231,7 @@ export class ConfigTemplateCard extends LitElement {
       }
     }
 
-    const localVars = this.getLovelaceConfig().variables;
+    const localVars = this.getLovelaceConfig();
 
     if (localVars) {
       if (Array.isArray(localVars)) {


### PR DESCRIPTION
If you need to use the same variable in multiple cards, then instead of defining it in each card's `variables` you can do that once for the entire dashboard.

```yaml
title: My dashboard
config_template_card:
  variables:
    - states['sensor.light'].state
views:
```

Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`. In the mixed mode, `vars` have array indices and as well as variable names.