### PR TITLE
Allow multiple templates anywhere in property value

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,29 @@ entities:
   - entity: light.bed_light
 ```
 
+### Markdown card example
+
+```yaml
+type: custom:config-template-card
+entities:
+  - sensor.outside_temperature
+  - sensor.time
+  - weather.home
+variables:
+  weather: |
+    () => {
+        let hass = document.querySelector("home-assistant").hass;
+        let w = states['weather.home'].state;
+        let key = 'component.weather.state._.' + w;
+        return hass.resources[hass.language][key];
+      }
+  card:
+    type: markdown
+    content: |
+      ### {{ states('sensor.outside_temperature') }} °C - ${weather()}
+      # {{ states('sensor.time') }}
+```
+
 ## Defining global functions in variables
 
 If you find yourself having to rewrite the same logic in multiple locations, you can define global methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -217,6 +217,12 @@ export class ConfigTemplateCard extends LitElement {
         }
       }
     }
-    return eval(varDef + template.substring(2, template.length - 1));
+
+    template.match(/\${[^}]+}/)!.forEach(m => {
+      const repl = eval(varDef + m.substring(2, m.length - 1));
+      template = template.replace(m, repl);
+    });
+
+    return template;
   }
 }

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -218,6 +218,12 @@ export class ConfigTemplateCard extends LitElement {
       }
     }
 
+    if (template.startsWith("${") && template.endsWith("}")) {
+        // The entire property is a template, return eval's result directly
+        // to preserve types other than string (eg. numbers)
+        return eval(varDef + template.substring(2, template.length - 1));
+    }
+
     template.match(/\${[^}]+}/)!.forEach(m => {
       const repl = eval(varDef + m.substring(2, m.length - 1));
       template = template.replace(m, repl);


### PR DESCRIPTION
Currently only entire property values can be a template. These changes make it possible to use multiple templates anywhere in a property value. Particularly useful in markdown cards. See the updated README for an example.

Attached is a compiled version that includes both this PR and #109.

[config-template-card.js.gz](https://github.com/iantrich/config-template-card/files/9540743/config-template-card.js.gz)
