### PR TITLE
Defensive programming for _evaluateTemplate

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -187,7 +187,7 @@ export class ConfigTemplateCard extends LitElement {
   }
 
   private _evaluateTemplate(template: string): string {
-    if (!template.includes('${')) {
+    if (!template.includes || !template.includes('${')) {
       return template;
     }
 


### PR DESCRIPTION
Per this [issue I had that I posted on the forum](https://community.home-assistant.io/t/help-with-dynamic-warning-card-for-one-or-more-entities-or-how-do-you-combine-filter-declutter-template-button-cards/520186/2), adding a defensive check that the template is really a template solves the error for me.

