### PR TITLE
More bug fixes, improvements, and features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,7 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:
@@ -20,9 +16,9 @@ jobs:
           npm install
           npm run build
 
-      - name: Archive distribution bundle
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           path: dist/config-template-card.js
-          name: config-template-card-latest-build.js
+          name: config-template-card.js
           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: Prepare Release
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,12 +17,12 @@ jobs:
           npm install
           npm run build
 
-      - name: Upload as Release
+      - name: Upload to Release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/config-template-card.js
-          asset_name: config-template-card.js
           tag: ${{ github.ref }}
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          file: dist/config-template-card.js
+          asset_name: config-template-card.js
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ views:
 
 Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`. In the mixed mode, `vars` have array indices and as well as variable names.
 
-### Note: All templates must be enclosed by `${}`
+### Note: All templates must be enclosed by `${}`, except when defining variables.
 
 [Troubleshooting](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ elements:
       type: icon
       icon: "${vars[0] === 'on' ? 'mdi:home' : 'mdi:circle'}"
       style:
-        '--paper-item-icon-color': '${ states[''sensor.light_icon_color''].state }'
+        '--paper-item-icon-color': "${ states['sensor.light_icon_color'].state }"
     style:
       top: 47%
       left: 75%
 ```
+
 The `style` object on the element configuration is applied to the element itself, the `style` object on the `config-template-card` is applied to the surrounding card. Both can contain templated values. For example, in order to place the card properly, the `top` and `left` attributes must always be configured on the `config-template-card`.
 
 ### Entities card example
@@ -198,7 +199,35 @@ card:
   entities:
     - entity: climate.ecobee
       name: '${ setTempMessage("House: ", currentTemp) }'
-````
+```
+
+### Asynchronous functions
+
+Asynchronous functions can be used in most templates.
+
+```yaml
+type: 'custom:config-template-card'
+entities:
+  - light.bed_light
+  - light.porch_light
+card:
+  type: entities
+  entities:
+    - entity: light.bed_light
+      name: "${(async () => states['light.bed_light'].state === 'on' ? 'Bed Light On' : 'Bed Light Off' )();}"
+    - entity: light.porch_light
+      name: "${(async () => { return states['light.bed_light'].state === 'on' ? 'Porch Light On' : 'Porch Light Off'; })();}"
+```
+
+Card rendering will be delayed until all asynchronous functions (in all templates) have completed, so long-running asynchronous functions may prevent the card from rendering on page load or delay updates to the card.
+
+When defining `staticVariables` that reference other (previously defined) `svars`, any referenced `svars` that use asynchronous functions will contain the unsettled `Promise` object.
+
+Similarly, when defining `variables` that reference other (previously defined) `vars`, any referenced `vars` that use asynchronous functions will contain the unsettled `Promise` object. However, any referenced `svars` that use asynchronous functions will contain complete/settled values.
+
+When defining `entities` that use templates, any `entities` templates that use asynchronous functions will be skipped, and any referenced `vars` that use asynchronous functions will contain the unsettled `Promise` object, which will not settle before `entities` is used. However, any referenced `svars` that use asynchronous functions will have complete/settled values.
+
+(The reason that asynchronous functions cannot be used for `entities` is that Lit does not support asynchronous functions in `shouldUpdate()` where `entities` is evaluated and used.  The alternative [lovelace-card-templater](https://github.com/gadgetchnnel/lovelace-card-templater) cannot support templates in its `entities` for the same reason; it uses API calls to render templates, and API calls require the use of asynchronous functions.)
 
 ### Dashboard wide variables
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ resources:
 
 Exactly one of `card`, `row`, or `element` is required.
 
+### Note: All templates must be enclosed by `${}`, except when defining variables.
+
+`${}` is optional in variable definitions (variables will be parsed as templates even without `${}`).
+
+Config values that begin with `${` and end with `}` are parsed as a single template, including any nested `${` and `}` sequences/characters.  For example, `${vars[0]}-${vars[1]}` will attempt to evaluate `vars[0]}-${vars[1]` and will fail due to the invalid `}` and `${`.
+
+Config values that do not begin with `${` and end with `}` may contain multiple templates, however those templates cannot contain `}` characters.  For example, `${vars[0]}-${vars[1]}:` will work as expected, but `${() => { return 0; }}:` will fail due to the `}` character in the template.
+
+Values that begin with `$! ` (`$!` followed by a space) will not be parsed for templates.  `$! ` will be stripped from the beginning of the value, but any `${}` sequences within the value will be left as-is.
+
 ### Available variables for templating
 
 | Variable    | Description                                                                        |
@@ -251,16 +261,6 @@ views:
 Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `svars`/`vars`. In the mixed mode, `svars`/`vars` have array indices as well as variable names.
 
 After making changes to these variable definitions in the HA Dashboard Editor, you must reload the browser on any currently-open clients before you will see the changes.  Unlike card config changes which automatically update currently-open clients, dashboard wide variable config changes will not automatically update currently-open clients.
-
-### Note: All templates must be enclosed by `${}`, except when defining variables.
-
-`${}` is optional in variable definitions (variables will be parsed as templates even without `${}`).
-
-Config values that begin with `${` and end with `}` are parsed as a single template, including any nested `${` and `}` sequences/characters.  For example, `${vars[0]}-${vars[1]}` will attempt to evaluate `vars[0]}-${vars[1]` and will fail due to the invalid `}` and `${`.
-
-Config values that do not begin with `${` and end with `}` may contain multiple templates, however those templates cannot contain `}` characters.  For example, `${vars[0]}-${vars[1]}:` will work as expected, but `${() => { return 0; }}:` will fail due to the `}` character in the template.
-
-Values that begin with `$! ` (`$!` followed by a space) will not be parsed for templates.  `$! ` will be stripped from the beginning of the value, but any `${}` sequences within the value will be left as-is.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -39,24 +39,27 @@ resources:
 
 ## Options
 
-| Name      | Type   | Requirement  | Description                                                                                                      |
-| --------- | ------ | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| type      | string | **Required** | `custom:config-template-card`                                                                                    |
-| entities  | list   | **Required** | List of entity strings that should be watched for updates. Templates can be used here                            |
-| variables | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `vars` or by name |
-| card      | object | **Optional** | Card configuration. (A card, row, or element configuaration must be provided)                                    |
-| row       | object | **Optional** | Row configuration. (A card, row, or element configuaration must be provided)                                     |
-| element   | object | **Optional** | Element configuration. (A card, row, or element configuaration must be provided)                                 |
-| style     | object | **Optional** | Style configuration.                                                                                             |
+| Name            | Type   | Requirement  | Description                                            |
+| --------------- | ------ | ------------ | ------------------------------------------------------ |
+| type            | string | **Required** | `custom:config-template-card`                                                                                    |
+| entities        | list   | **Required** | List of entity strings that should be watched for updates. Templates can be used here                            |
+| variables       | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `vars` or by name. These are evaluated on each update/render. |
+| staticVariables | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `svars` or by name. These are evaluated only on the first update/render and are preserved without re-evaluation for subsequent updates. |
+| card            | object | **Optional** | Card configuration. (A card, row, or element configuration must be provided)                                    |
+| row             | object | **Optional** | Row configuration. (A card, row, or element configuration must be provided)                                     |
+| element         | object | **Optional** | Element configuration. (A card, row, or element configuration must be provided)                                 |
+| style           | object | **Optional** | Style configuration.                                                                                             |
 
 ### Available variables for templating
 
-| Variable    | Description                                                                                                                                                                                                                                                                                                                                                                                           |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variable    | Description                                                                        |
+| ----------- | ---------------------------------------------------------------------------------- |
 | `hass`      | The [hass](https://developers.home-assistant.io/docs/frontend/data/) object                                                                                                                                                                                                                                                                                                                           |
 | `states`    | The [states](https://developers.home-assistant.io/docs/frontend/data/#hassstates) object                                                                                                                                                                                                                                                                                                              |
 | `user`      | The [user](https://developers.home-assistant.io/docs/frontend/data/#hassuser) object                                                                                                                                                                                                                                                                                                                  |
 | `vars`      | Defined by `variables` configuration and accessible in your templates to help clean them up. If `variables` in the configuration is a yaml list, then `vars` is an array starting at the 0th index as your firstly defined variable. If `variables` is an object in the configuration, then `vars` is a string-indexed map and you can also access the variables by name without using `vars` at all. |
+| `svars`     | Defined by `staticVariables` configuration and accessible in your templates to avoid redundant expensive operations. If `staticVariables` in the configuration is a yaml list, then `svars` is an array starting at the 0th index as your firstly defined variable. If `staticVariables` is an object in the configuration, then `svars` is a string-indexed map and you can also access the variables by name without using `svars` at all. |
+
 ## Examples
 
 ```yaml
@@ -194,6 +197,8 @@ title: My dashboard
 
 config_template_card_vars:
   - states['sensor.light'].state
+config_template_card_staticVars:
+  lang: document.documentElement.lang
 
 views:
 ```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Exactly one of `card`, `row`, or `element` is required.
 | `hass`      | The [hass](https://developers.home-assistant.io/docs/frontend/data/) object.       |
 | `states`    | The [states](https://developers.home-assistant.io/docs/frontend/data/#hassstates) object. |
 | `user`      | The [user](https://developers.home-assistant.io/docs/frontend/data/#hassuser) object. |
+| `config`    | The configuration provided to config-template-card. This is read-only, includes the unevaluated templates, and does not include any dashboard-wide `config_template_card_staticVars` or `config_template_card_vars` values. |
 | `svars`     | Defined by `staticVariables` configuration and accessible in your templates to avoid redundant expensive operations. If `staticVariables` in the configuration is a yaml list, then `svars` is an array starting with index 0. If `staticVariables` in the configuration is an object, then `svars` is a string-indexed map and you can also access the variables by name without using `svars` at all. |
 | `vars`      | Defined by `variables` configuration and accessible in your templates to help clean them up. If `variables` in the configuration is a yaml list, then `vars` is an array starting with index 0. If `variables` in the configuration is an object, then `vars` is a string-indexed map and you can also access the variables by name without using `vars` at all. |
+| `output`    | While evaluating the `card`, `row`, or `element` configuration, `output` contains the partially assembled/evaluated copy of that config section. This may be used, for example, to reference a nested card's `type` or `entities` in a template for that card's `name` without requiring the referenced values to be defined in `variables`. |
 
 ## Examples
 
@@ -224,6 +226,8 @@ Card rendering will be delayed until all asynchronous functions (in all template
 When defining `staticVariables` that reference other (previously defined) `svars`, any referenced `svars` that use asynchronous functions will contain the unsettled `Promise` object.
 
 Similarly, when defining `variables` that reference other (previously defined) `vars`, any referenced `vars` that use asynchronous functions will contain the unsettled `Promise` object. However, any referenced `svars` that use asynchronous functions will contain complete/settled values.
+
+Also similarly, when evaluating the `card`, `row`, or `element` configuration, any `output` values that use asynchronous functions will contain the unsettled `Promise` object.  However, any referenced `svars` or `vars` that use asynchronous functions will contain complete/settled values.
 
 When defining `entities` that use templates, any `entities` templates that use asynchronous functions will be skipped, and any referenced `vars` that use asynchronous functions will contain the unsettled `Promise` object, which will not settle before `entities` is used. However, any referenced `svars` that use asynchronous functions will have complete/settled values.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Config Template Card Card
+# Config Template Card
 
-📝 Templatable Configuration Card
+📝 Template Based Configuration for Lovelace Dashboard Cards
 
 [![GitHub Release][releases-shield]][releases]
 [![License][license-shield]](LICENSE.md)
@@ -15,13 +15,23 @@
 [![Twitter][twitter]][twitter]
 [![Github][github]][github]
 
-This card is for [Lovelace](https://www.home-assistant.io/lovelace) on [Home Assistant](https://www.home-assistant.io/) that allows you to use pretty much any valid Javascript on the hass object in your configuration
+## Overview
 
-## Minimum Home Assistant Version
+This [Home Assistant](https://www.home-assistant.io/) [Lovelace Dashboard](https://www.home-assistant.io/dashboards) Card supports the use of Javascript templates to dynamically configure other nested Dashboard Cards.
 
-Home Assistant version 0.110.0 or higher is required as of release 1.2.0 of config-template-card
+### Template Language
 
-## Support
+Note that this Card uses **Javascript** templates. It does NOT support the **Jinja2** templates that are used elsewhere in Home Assistant.
+
+This is because Dashboard Cards are normally rendered entirely in the web browser using Javascript, while Jinja2 templates must be rendered by Python on the Home Assistant server. The use of Javascript for templates enables this Card to render templates in the browser without deviating from the expected design pattern of Dashboard Cards.
+
+For an alternative Card that does support Jinja2 templates, see [lovelace-card-templater](https://github.com/gadgetchnnel/lovelace-card-templater). That Card works by making API calls from the browser to the Home Assistant server to render each template.
+
+### Minimum Home Assistant Version
+
+Home Assistant version 0.110.0 or higher is required as of release 1.2.0 of config-template-card.
+
+### Support
 
 Hey dude! Help me out for a couple of :beers: or a :coffee:!
 
@@ -37,28 +47,30 @@ resources:
     type: module
 ```
 
-## Options
+## Configuration
 
-| Name            | Type   | Requirement  | Description                                            |
-| --------------- | ------ | ------------ | ------------------------------------------------------ |
-| type            | string | **Required** | `custom:config-template-card`                                                                                    |
-| entities        | list   | **Required** | List of entity strings that should be watched for updates. Templates can be used here                            |
-| variables       | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `vars` or by name. These are evaluated on each update/render. |
-| staticVariables | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `svars` or by name. These are evaluated only on the first update/render and are preserved without re-evaluation for subsequent updates. |
-| card            | object | **Optional** | Card configuration. (A card, row, or element configuration must be provided)                                    |
-| row             | object | **Optional** | Row configuration. (A card, row, or element configuration must be provided)                                     |
-| element         | object | **Optional** | Element configuration. (A card, row, or element configuration must be provided)                                 |
-| style           | object | **Optional** | Style configuration.                                                                                             |
+| Name            | Type        | Requirement  | Description                                       |
+| --------------- | ----------- | ------------ | ------------------------------------------------- |
+| type            | string      | **Required** | Must be `custom:config-template-card`             |
+| entities        | list        | **Optional** | List of entity strings that should be watched for updates. Templates can be used here. |
+| staticVariables | list/object | **Optional** | List of variables, which can be templates, that can be used in other templates and indexed using `svars` or by name. These are evaluated only on the first update/render and are preserved without re-evaluation for subsequent updates. |
+| variables       | list/object | **Optional** | List of variables, which can be templates, that can be used in other templates and indexed using `vars` or by name. These are evaluated on each update/render. |
+| card            | object      | **Optional** | Card configuration.                               |
+| row             | object      | **Optional** | Row configuration.                                |
+| element         | object      | **Optional** | Element configuration.                            |
+| style           | object      | **Optional** | Element Style configuration. Can only be used with `element`.    |
+
+Exactly one of `card`, `row`, or `element` is required.
 
 ### Available variables for templating
 
 | Variable    | Description                                                                        |
 | ----------- | ---------------------------------------------------------------------------------- |
-| `hass`      | The [hass](https://developers.home-assistant.io/docs/frontend/data/) object                                                                                                                                                                                                                                                                                                                           |
-| `states`    | The [states](https://developers.home-assistant.io/docs/frontend/data/#hassstates) object                                                                                                                                                                                                                                                                                                              |
-| `user`      | The [user](https://developers.home-assistant.io/docs/frontend/data/#hassuser) object                                                                                                                                                                                                                                                                                                                  |
-| `vars`      | Defined by `variables` configuration and accessible in your templates to help clean them up. If `variables` in the configuration is a yaml list, then `vars` is an array starting at the 0th index as your firstly defined variable. If `variables` is an object in the configuration, then `vars` is a string-indexed map and you can also access the variables by name without using `vars` at all. |
-| `svars`     | Defined by `staticVariables` configuration and accessible in your templates to avoid redundant expensive operations. If `staticVariables` in the configuration is a yaml list, then `svars` is an array starting at the 0th index as your firstly defined variable. If `staticVariables` is an object in the configuration, then `svars` is a string-indexed map and you can also access the variables by name without using `svars` at all. |
+| `hass`      | The [hass](https://developers.home-assistant.io/docs/frontend/data/) object.       |
+| `states`    | The [states](https://developers.home-assistant.io/docs/frontend/data/#hassstates) object. |
+| `user`      | The [user](https://developers.home-assistant.io/docs/frontend/data/#hassuser) object. |
+| `svars`     | Defined by `staticVariables` configuration and accessible in your templates to avoid redundant expensive operations. If `staticVariables` in the configuration is a yaml list, then `svars` is an array starting with index 0. If `staticVariables` in the configuration is an object, then `svars` is a string-indexed map and you can also access the variables by name without using `svars` at all. |
+| `vars`      | Defined by `variables` configuration and accessible in your templates to help clean them up. If `variables` in the configuration is a yaml list, then `vars` is an array starting with index 0. If `variables` in the configuration is an object, then `vars` is a string-indexed map and you can also access the variables by name without using `vars` at all. |
 
 ## Examples
 
@@ -120,7 +132,7 @@ elements:
       top: 47%
       left: 75%
 ```
-The `style` object on the element configuration is applied to the element itself, the `style` object on the `config-template-card` is applied to the surrounding card, both can contain templated values. For example, in order to place the card properly, the `top` and `left` attributes must always be configured on the `config-template-card`.
+The `style` object on the element configuration is applied to the element itself, the `style` object on the `config-template-card` is applied to the surrounding card. Both can contain templated values. For example, in order to place the card properly, the `top` and `left` attributes must always be configured on the `config-template-card`.
 
 ### Entities card example
 
@@ -161,31 +173,31 @@ variables:
       # {{ states('sensor.time') }}
 ```
 
-### Defining global functions in variables
+### Defining functions in variables
 
-If you find yourself having to rewrite the same logic in multiple locations, you can define global methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:
+If you find yourself having to rewrite the same logic in multiple locations, you can define methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:
 
 ```yaml
 type: 'custom:config-template-card'
-  variables:
-    setTempMessage: |
-      (prefix, temp) => {
-        if (temp <= 19) {
-            return prefix + 'Quick, get a blanket!';
-        }
-        else if (temp >= 20 && temp <= 22) {
-          return prefix + 'Cozy!';
-        }
-        return prefix + 'It's getting hot in here...';
+variables:
+  setTempMessage: |
+    (prefix, temp) => {
+      if (temp <= 19) {
+          return prefix + 'Quick, get a blanket!';
       }
-    currentTemp: states['climate.ecobee'].attributes.current_temperature
+      else if (temp >= 20 && temp <= 22) {
+        return prefix + 'Cozy!';
+      }
+      return prefix + 'It's getting hot in here...';
+    }
+  currentTemp: states['climate.ecobee'].attributes.current_temperature
+entities:
+  - climate.ecobee
+card:
+  type: entities
   entities:
-    - climate.ecobee
-  card:
-    type: entities
-    entities:
-      - entity: climate.ecobee
-        name: '${ setTempMessage("House: ", currentTemp) }'
+    - entity: climate.ecobee
+      name: '${ setTempMessage("House: ", currentTemp) }'
 ````
 
 ### Dashboard wide variables
@@ -195,15 +207,17 @@ If you need to use the same variable in multiple cards, then instead of defining
 ```yaml
 title: My dashboard
 
-config_template_card_vars:
-  - states['sensor.light'].state
 config_template_card_staticVars:
   lang: document.documentElement.lang
+config_template_card_vars:
+  - states['sensor.light'].state
 
 views:
 ```
 
-Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`. In the mixed mode, `vars` have array indices and as well as variable names.
+Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `svars`/`vars`. In the mixed mode, `svars`/`vars` have array indices as well as variable names.
+
+After making changes to these variable definitions in the HA Dashboard Editor, you must reload the browser on any currently-open clients before you will see the changes.  Unlike card config changes which automatically update currently-open clients, dashboard wide variable config changes will not automatically update currently-open clients.
 
 ### Note: All templates must be enclosed by `${}`, except when defining variables.
 
@@ -224,6 +238,7 @@ Values that begin with `$! ` (`$!` followed by a space) will not be parsed for t
 Fork and then clone the repo to your local machine. From the cloned directory run
 
 `npm install && npm run build`
+
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/custom-cards/config-template-card.svg?style=for-the-badge
 [commits]: https://github.com/custom-cards/config-template-card/commits/master

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ variables:
       # {{ states('sensor.time') }}
 ```
 
-## Defining global functions in variables
+### Defining global functions in variables
 
 If you find yourself having to rewrite the same logic in multiple locations, you can define global methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:
 
@@ -185,7 +185,7 @@ type: 'custom:config-template-card'
         name: '${ setTempMessage("House: ", currentTemp) }'
 ````
 
-## Dashboard wide variables
+### Dashboard wide variables
 
 If you need to use the same variable in multiple cards, then instead of defining it in each card's `variables` you can do that once for the entire dashboard.
 
@@ -202,7 +202,17 @@ Both arrays and objects are supported, just like in card's local variables. It i
 
 ### Note: All templates must be enclosed by `${}`, except when defining variables.
 
-[Troubleshooting](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)
+`${}` is optional in variable definitions (variables will be parsed as templates even without `${}`).
+
+Config values that begin with `${` and end with `}` are parsed as a single template, including any nested `${` and `}` sequences/characters.  For example, `${vars[0]}-${vars[1]}` will attempt to evaluate `vars[0]}-${vars[1]` and will fail due to the invalid `}` and `${`.
+
+Config values that do not begin with `${` and end with `}` may contain multiple templates, however those templates cannot contain `}` characters.  For example, `${vars[0]}-${vars[1]}:` will work as expected, but `${() => { return 0; }}:` will fail due to the `}` character in the template.
+
+Values that begin with `$! ` (`$!` followed by a space) will not be parsed for templates.  `$! ` will be stripped from the beginning of the value, but any `${}` sequences within the value will be left as-is.
+
+## Troubleshooting
+
+[General HA Plugin Troubleshooting](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)
 
 ## Developers
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,6 @@ Hey dude! Help me out for a couple of :beers: or a :coffee:!
 
 Use [HACS](https://hacs.xyz) or follow this [guide](https://github.com/thomasloven/hass-config/wiki/Lovelace-Plugins)
 
-```yaml
-resources:
-  - url: /local/config-template-card.js
-    type: module
-```
-
 ## Configuration
 
 (If you are new to config-template-card, you may want to skim the [Examples](#Examples) first, then return to this section for more details.)
@@ -121,33 +115,47 @@ Templates may define additional Javascript variables, but they will be local to 
 
 ## Examples
 
+### General example
+
 ```yaml
-type: 'custom:config-template-card'
+type: custom:config-template-card
 variables:
-  LIGHT_STATE: states['light.bed_light'].state
-  GARAGE_STATE: states['cover.garage_door'].state
+  LIGHT_ENTITY: '$! light.bed_light'
+  LIGHT_STATE: '<$ states[LIGHT_ENTITY].state $>'
+  GARAGE_STATE: '<$ states["cover.garage_door"].state $>'
 entities:
-  - light.bed_light
+  - '<$ LIGHT_ENTITY $>'
   - cover.garage_door
   - alarm_control_panel.alarm
   - climate.ecobee
 card:
-  type: "${LIGHT_STATE === 'on' ? 'glance' : 'entities'}"
+  type: '<$ LIGHT_STATE === "on" ? "glance" : "entities" $>'
   entities:
-    - entity: alarm_control_panel.alarm
-      name: "${GARAGE_STATE === 'open' && states['alarm_control_panel.alarm'].state === 'armed_home' ? 'Close the garage!' : ''}"
-    - entity: binary_sensor.basement_floor_wet
-    - entity: climate.ecobee
-      name: "${states['climate.ecobee'].attributes.current_temperature > 22 ? 'Cozy' : 'Too Hot/Cold'}"
+    - entity: '<$ LIGHT_STATE === "on" ? LIGHT_ENTITY : "climate.ecobee" $>'
+      icon: |-
+        <$ GARAGE_STATE === 'open' ? 'mdi:hotel' : '' $>
     - entity: cover.garage_door
-    - entity: "${LIGHT_STATE === 'on' ? 'light.bed_light' : 'climate.ecobee'}"
-      icon: "${GARAGE_STATE === 'open' ? 'mdi:hotel' : '' }"
+    - entity: alarm_control_panel.alarm
+      name: |-
+        <$
+        (function() {
+          if (GARAGE_STATE === 'open' && states['alarm_control_panel.alarm'].state === 'armed_home') {
+            return 'Close the garage!';
+          }
+          return '';
+        })();
+        $>
+    - entity: climate.ecobee
+      name: '<$ states["climate.ecobee"].attributes.current_temperature > 22 ? "Cozy" : "Too Hot/Cold" $>'
 ```
+
+Notes:
+TODO
 
 ### Templated entities example
 
 ```yaml
-type: 'custom:config-template-card'
+type: custom:config-template-card
 variables:
   - states['sensor.light']
 entities:
@@ -164,7 +172,7 @@ card:
 type: picture-elements
 image: http://hs.sbcounty.gov/CN/Photo%20Gallery/_t/Sample%20Picture%20-%20Koala_jpg.jpg?Mobile=0
 elements:
-  - type: 'custom:config-template-card'
+  - type: custom:config-template-card
     variables:
       - states['light.bed_light'].state
     entities:
@@ -187,7 +195,7 @@ The `style` object on the element configuration is applied to the element itself
 ```yaml
 type: entities
 entities:
-  - type: 'custom:config-template-card'
+  - type: custom:config-template-card
     variables:
       - states['light.bed_light'].state
     entities:
@@ -226,7 +234,7 @@ variables:
 If you find yourself having to rewrite the same logic in multiple locations, you can define methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:
 
 ```yaml
-type: 'custom:config-template-card'
+type: custom:config-template-card
 variables:
   setTempMessage: |
     (prefix, temp) => {
@@ -253,7 +261,7 @@ card:
 Asynchronous functions can be used in most templates.
 
 ```yaml
-type: 'custom:config-template-card'
+type: custom:config-template-card
 entities:
   - light.bed_light
   - light.porch_light

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,7 @@ export default ts.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/non-nullable-type-assertion-style': 'off',
     },
     languageOptions: {
       sourceType: 'module',  // Allows for the use of imports

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default ts.config(
       '@typescript-eslint/no-unused-vars': ['warn', {'argsIgnorePattern': '^_'}],
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
     },
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,19 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
@@ -67,9 +80,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
-      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -80,9 +93,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -104,9 +117,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
-      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -124,27 +137,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -203,6 +203,7 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.4.tgz",
       "integrity": "sha512-j5C6NyfKevIxsfLK8KwO1C0vvP7k1+h4A9cFpc+cr6mEwCc1sPkr17dzh0Ke6k9U5pQccAQoXdcNBl3IYa4+ZQ==",
+      "deprecated": "the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package",
       "license": "MIT",
       "dependencies": {
         "emojis-list": "^3.0.0"
@@ -261,9 +262,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -424,10 +425,206 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz",
+      "integrity": "sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.9.tgz",
+      "integrity": "sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.9.tgz",
+      "integrity": "sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.9.tgz",
+      "integrity": "sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.9.tgz",
+      "integrity": "sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.9.tgz",
+      "integrity": "sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.9.tgz",
+      "integrity": "sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.9.tgz",
+      "integrity": "sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.9.tgz",
+      "integrity": "sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.9.tgz",
+      "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.9.tgz",
+      "integrity": "sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.9.tgz",
+      "integrity": "sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.9.tgz",
+      "integrity": "sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.9.tgz",
+      "integrity": "sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.7",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.7.tgz",
-      "integrity": "sha512-9kPVf9ahnpOMSGlCxXGv980wXD0zRR3wyk8+33/MXQIpQEOpaNe7dEHm5LMfyRZRNt9lMEQuH0jUKj15MkM7QA==",
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
       "cpu": [
         "x64"
       ],
@@ -439,9 +636,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.7",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.7.tgz",
-      "integrity": "sha512-7wJPXRWTTPtTFDFezA8sle/1sdgxDjuMoRXEKtx97ViRxGGkVQYovem+Q8Pr/2HxiHp74SSRG+o6R0Yq0shPwQ==",
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.9.tgz",
+      "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
       ],
@@ -450,6 +647,48 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.9.tgz",
+      "integrity": "sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.9.tgz",
+      "integrity": "sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.9.tgz",
+      "integrity": "sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@types/estree": {
@@ -480,17 +719,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.0.tgz",
-      "integrity": "sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
+      "integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/type-utils": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/type-utils": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -510,16 +749,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.0.tgz",
-      "integrity": "sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
+      "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/typescript-estree": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -535,14 +774,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.0.tgz",
-      "integrity": "sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
+      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0"
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -553,14 +792,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.0.tgz",
-      "integrity": "sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
+      "integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0",
+        "@typescript-eslint/typescript-estree": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -577,9 +816,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.0.tgz",
-      "integrity": "sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
+      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -591,14 +830,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.0.tgz",
-      "integrity": "sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
+      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/visitor-keys": "8.24.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/visitor-keys": "8.25.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -644,16 +883,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.0.tgz",
-      "integrity": "sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
+      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.24.0",
-        "@typescript-eslint/types": "8.24.0",
-        "@typescript-eslint/typescript-estree": "8.24.0"
+        "@typescript-eslint/scope-manager": "8.25.0",
+        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -668,13 +907,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.0.tgz",
-      "integrity": "sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
+      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.24.0",
+        "@typescript-eslint/types": "8.25.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -683,19 +922,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/acorn": {
@@ -972,22 +1198,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
-      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.11.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.20.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -1049,19 +1275,6 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
@@ -1085,19 +1298,6 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1210,9 +1410,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1277,11 +1477,25 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1852,9 +2066,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1863,9 +2077,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.34.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.7.tgz",
-      "integrity": "sha512-8qhyN0oZ4x0H6wmBgfKxJtxM7qS98YJ0k0kNh5ECVtuchIJ7z9IVVvzpmtQyT10PXKMtBxYr1wQ5Apg8RS8kXQ==",
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.9.tgz",
+      "integrity": "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1879,25 +2093,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.7",
-        "@rollup/rollup-android-arm64": "4.34.7",
-        "@rollup/rollup-darwin-arm64": "4.34.7",
-        "@rollup/rollup-darwin-x64": "4.34.7",
-        "@rollup/rollup-freebsd-arm64": "4.34.7",
-        "@rollup/rollup-freebsd-x64": "4.34.7",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.7",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.7",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.7",
-        "@rollup/rollup-linux-arm64-musl": "4.34.7",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.7",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.7",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.7",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.7",
-        "@rollup/rollup-linux-x64-gnu": "4.34.7",
-        "@rollup/rollup-linux-x64-musl": "4.34.7",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.7",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.7",
-        "@rollup/rollup-win32-x64-msvc": "4.34.7",
+        "@rollup/rollup-android-arm-eabi": "4.34.9",
+        "@rollup/rollup-android-arm64": "4.34.9",
+        "@rollup/rollup-darwin-arm64": "4.34.9",
+        "@rollup/rollup-darwin-x64": "4.34.9",
+        "@rollup/rollup-freebsd-arm64": "4.34.9",
+        "@rollup/rollup-freebsd-x64": "4.34.9",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.9",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.9",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.9",
+        "@rollup/rollup-linux-arm64-musl": "4.34.9",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.9",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.9",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-gnu": "4.34.9",
+        "@rollup/rollup-linux-x64-musl": "4.34.9",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.9",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.9",
+        "@rollup/rollup-win32-x64-msvc": "4.34.9",
         "fsevents": "~2.3.2"
       }
     },
@@ -2089,15 +2303,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.24.0.tgz",
-      "integrity": "sha512-/lmv4366en/qbB32Vz5+kCNZEMf6xYHwh1z48suBwZvAtnXKbP+YhGe8OLE2BqC67LMqKkCNLtjejdwsdW6uOQ==",
+      "version": "8.25.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
+      "integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.24.0",
-        "@typescript-eslint/parser": "8.24.0",
-        "@typescript-eslint/utils": "8.24.0"
+        "@typescript-eslint/eslint-plugin": "8.25.0",
+        "@typescript-eslint/parser": "8.25.0",
+        "@typescript-eslint/utils": "8.25.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -264,7 +264,7 @@ export class ConfigTemplateCard extends LitElement {
       return this._evalWithVars(template.substring(2, template.length - 1));
     }
 
-    const matches = /\${[^}]+}/.exec(template);
+    const matches = template.match(/\${[^}]+}/g);
     if (matches) {
       matches.forEach(m => {
         const repl = this._evalWithVars(m.substring(2, m.length - 1), '<error>').toString() as string;

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -173,8 +173,8 @@ export class ConfigTemplateCard extends LitElement {
 
   private _evaluateVars(): void {
     const vars: Record<string, any> & any[] = [];
-    const namedVars: Record<string, any> = {};
-    const arrayVars: any[] = [];
+    let namedVars: Record<string, any> = {};
+    let arrayVars: any[] = [];
 
     Object.assign(this._varMgr, {
       hass: this.hass, states: this.hass?.states, user: this.hass?.user, vars: vars,
@@ -201,16 +201,18 @@ export class ConfigTemplateCard extends LitElement {
       }
     }
 
+    arrayVars = structuredClone(arrayVars);
     for (let v of arrayVars) {
-      if (isString(v)) { v = this._evalWithVars(v); }
-      else { v = structuredClone(v); }
+      if (isString(v) && !v.includes('${')) { v = this._evalWithVars(v); }
+      else { v = this._evaluateStructure(v); }
       vars.push(v);
     }
 
+    namedVars = structuredClone(namedVars);
     for (const varName in namedVars) {
       let v = namedVars[varName];
-      if (isString(v)) { v = this._evalWithVars(v); }
-      else { v = structuredClone(v); }
+      if (isString(v) && !v.includes('${')) { v = this._evalWithVars(v); }
+      else { v = this._evaluateStructure(v); }
       vars[varName] = v;
       this._varMgr._evalInitVars += `var ${varName} = vars['${varName}'];\n`;
     }

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -182,16 +182,17 @@ export class ConfigTemplateCard extends LitElement {
     // TypeScript can't detect this if it is set in Object.assign()
     this._varMgr._evalInitVars = '';
 
-    if (this._config?.variables) {
-      if (Array.isArray(this._config.variables)) {
+    const globalVars = this.getLovelaceConfig();
+    if (globalVars) {
+      if (Array.isArray(globalVars)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        arrayVars.push(...this._config.variables);
+        arrayVars.push(...globalVars);
       } else {
-        Object.assign(namedVars, this._config.variables);
+        Object.assign(namedVars, globalVars);
       }
     }
 
-    const localVars = this.getLovelaceConfig();
+    const localVars = this._config?.variables;
     if (localVars) {
       if (Array.isArray(localVars)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,18 +5,14 @@ import { HassEntities } from 'home-assistant-js-websocket';
 export type ObjMap = Record<string, any>;
 export type Vars = ObjMap | any[];
 
-interface StyleMixin {
-  style?: Record<string, string>;
-}
-
 export interface Config {
   type: string;
   entities?: string[];
   variables?: Vars;
   staticVariables?: Vars;
-  card?: LovelaceCardConfig & StyleMixin;
-  row?: EntitiesCardEntityConfig & StyleMixin;
-  element?: LovelaceElementConfigBase & StyleMixin;
+  card?: LovelaceCardConfig;
+  row?: EntitiesCardEntityConfig;
+  element?: LovelaceElementConfigBase;
   style?: Record<string, string>;
 }
 
@@ -30,9 +26,11 @@ export interface VarMgr {
   hass: HomeAssistant;
   states: HassEntities;
   user: CurrentUser;
+  config: Config;
   svars: Vars;
   _evalInitSVars: string;
-  vars: Vars;
+  vars?: Vars;
   _evalInitVars: string;
   _varsPromise?: Promise<any>;
+  output?: ObjMap;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,24 +2,29 @@ import { LovelaceCardConfig, EntitiesCardEntityConfig, LovelaceElementConfigBase
 import { HomeAssistant, CurrentUser } from 'custom-card-helpers';
 import { HassEntities } from 'home-assistant-js-websocket';
 
+export type Vars = Record<string, any> | any[];
+
 interface StyleMixin {
   style?: Record<string, string>;
 }
 
-export interface ConfigTemplateConfig {
+export interface Config {
   type: string;
   entities?: string[];
-  variables?: Record<string, any> | any[];
+  variables?: Vars;
+  staticVariables?: Vars;
   card?: LovelaceCardConfig & StyleMixin;
   row?: EntitiesCardEntityConfig & StyleMixin;
   element?: LovelaceElementConfigBase & StyleMixin;
   style?: Record<string, string>;
 }
 
-export interface ConfigTemplateVarMgr {
+export interface VarMgr {
   hass?: HomeAssistant;
   states?: HassEntities;
   user?: CurrentUser;
-  vars?: Record<string, any> & any[];
+  vars?: Vars;
   _evalInitVars?: string;
+  svars?: Vars;
+  _evalInitSVars?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface Config {
 export interface SVarMgr {
   svars: Vars;
   _evalInitSVars: string;
+  _svarsPromise?: Promise<any>;
 }
 
 export interface VarMgr {
@@ -33,4 +34,5 @@ export interface VarMgr {
   _evalInitSVars: string;
   vars: Vars;
   _evalInitVars: string;
+  _varsPromise?: Promise<any>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@ import { LovelaceCardConfig, EntitiesCardEntityConfig, LovelaceElementConfigBase
 import { HomeAssistant, CurrentUser } from 'custom-card-helpers';
 import { HassEntities } from 'home-assistant-js-websocket';
 
-export type Vars = Record<string, any> | any[];
+export type ObjMap = Record<string, any>;
+export type Vars = ObjMap | any[];
 
 interface StyleMixin {
   style?: Record<string, string>;
@@ -19,12 +20,17 @@ export interface Config {
   style?: Record<string, string>;
 }
 
+export interface SVarMgr {
+  svars: Vars;
+  _evalInitSVars: string;
+}
+
 export interface VarMgr {
-  hass?: HomeAssistant;
-  states?: HassEntities;
-  user?: CurrentUser;
-  vars?: Vars;
-  _evalInitVars?: string;
-  svars?: Vars;
-  _evalInitSVars?: string;
+  hass: HomeAssistant;
+  states: HassEntities;
+  user: CurrentUser;
+  svars: Vars;
+  _evalInitSVars: string;
+  vars: Vars;
+  _evalInitVars: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,10 @@ export interface ConfigTemplateConfig {
   style?: Record<string, string>;
 }
 
-export interface ConfigTemplateVars {
+export interface ConfigTemplateVarMgr {
   hass?: HomeAssistant;
   states?: HassEntities;
   user?: CurrentUser;
-  vars: Record<string, any> & any[];
-  _evalInit: string;
+  vars?: Record<string, any> & any[];
+  _evalInitVars?: string;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,17 @@
-export function isString(testObj: any): testObj is string {
-  return (typeof testObj === 'string' || testObj instanceof String);
+export function assertNotNull<T>(value: T | null | undefined): asserts value is T {
+  if (value == null) {
+    throw new Error('Unexpected null or undefined value');
+  }
+}
+
+export function isString(value: any): value is string {
+  return (typeof value === 'string' || value instanceof String);
+}
+
+export function isPromise(value: any): value is Promise<any> {
+  return Boolean(value && typeof value.then === 'function');
+}
+
+export function somePromise(arr: any[]): boolean {
+  return arr.some((v) => isPromise(v));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "lib": [
-      "es2017",
+      "es2019",
       "dom",
       "dom.iterable"
     ],


### PR DESCRIPTION
Primary changes:
* Use strict mode in eval() to keep the global javascript variable namespace clean.
* Switch from `${ }` to `<$ $>` template delimiters.  (Old delimiters are still supported in cases where they were originally supported, but new delimiters are needed for some new use cases.  See #166 for details.)
* Allow template delimiters in variables.
* Allow disabling template parsing per value using a `$!` prefix.
* Add support for "static" variables that are evaluated once when the card is loaded, rather than on every update.
* Add `config` and `output` template variables.
* Add support for templates that return Promises / use asynchronous functions.  (Based on #149, with some changes/improvements.)

After this is merged, my opinion is that the dev branch is good enough to be merged into master.
However, of course, feel free to leave this in dev for now and do another beta release if you aren't comfortable with merging into master yet.

Closes #149, closes #160, closes #166.