### PR TITLE
docs: Examples for "config" & "output"

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,25 @@ variables:
       # {{ states('sensor.time') }}
 ```
 
+## Using `config`
+```yaml
+type: custom:config-template-card
+entities:
+  - sun.sun
+card:
+  type: history-graph
+  title: >-
+    ${
+      Number(config.card.hours_to_show) >= 24
+        ? 'day or more'
+        : 'less than a day'
+    }
+  entities:
+    - entity: sun.sun
+  hours_to_show: 4
+```
+
+
 ## Defining global functions in variables
 
 If you find yourself having to rewrite the same logic in multiple locations, you can define global methods inside Config Template Card's variables, which can be called anywhere within the scope of the card:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ variables:
       # {{ states('sensor.time') }}
 ```
 
-## Using `config`
+### `config` example
 ```yaml
 type: custom:config-template-card
 entities:
@@ -176,7 +176,7 @@ card:
   hours_to_show: 4
 ```
 
-## Using `output`
+### `output` example
 ```yaml
 type: custom:config-template-card
 variables:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ variables:
 ```
 
 ### `config` example
+
 ```yaml
 type: custom:config-template-card
 entities:
@@ -177,6 +178,7 @@ card:
 ```
 
 ### `output` example
+
 ```yaml
 type: custom:config-template-card
 variables:

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ card:
   type: entities
   entities: ${ENTITIES}
   title: >-
-    total: ${output.entities[0].length}
+    total: ${output.entities.length}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ card:
   hours_to_show: 4
 ```
 
+## Using `output`
+```yaml
+type: custom:config-template-card
+variables:
+  ENTITIES: |-
+    Object.keys(states)
+      .filter(
+        k => (
+          k.search('sensor.battery*') != -1
+        )
+      )
+entities: ${ENTITIES}
+card:
+  type: entities
+  entities: ${ENTITIES}
+  title: >-
+    total: ${output.entities[0].length}
+```
+
+
 
 ## Defining global functions in variables
 


### PR DESCRIPTION
Added examples for `config` & `output`.
Should be properly merged along with resolving conflicts.