### PR TITLE
Add possibility to define view wide variables as well as dashboard or view wide entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ resources:
 
 ## Options
 
-| Name      | Type   | Requirement  | Description                                                                                                      |
-| --------- | ------ | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| type      | string | **Required** | `custom:config-template-card`                                                                                    |
-| entities  | list   | **Required** | List of entity strings that should be watched for updates. Templates can be used here                            |
-| variables | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `vars` or by name |
-| card      | object | **Optional** | Card configuration. (A card, row, or element configuaration must be provided)                                    |
-| row       | object | **Optional** | Row configuration. (A card, row, or element configuaration must be provided)                                     |
-| element   | object | **Optional** | Element configuration. (A card, row, or element configuaration must be provided)                                 |
-| style     | object | **Optional** | Style configuration.                                                                                             |
+| Name      | Type   | Requirement  | Description                                                                                                                                                            |
+| --------- | ------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type      | string | **Required** | `custom:config-template-card`                                                                                                                                          |
+| entities  | list   | **Optional** | List of entity strings that should be watched for updates. Templates can be used here. Optional only if there are dashboard or view wide entities, otherwise required. |
+| variables | list   | **Optional** | List of variables, which can be templates, that can be used in your `config` and indexed using `vars` or by name                                                       |
+| card      | object | **Optional** | Card configuration. (A card, row, or element configuaration must be provided)                                                                                          |
+| row       | object | **Optional** | Row configuration. (A card, row, or element configuaration must be provided)                                                                                           |
+| element   | object | **Optional** | Element configuration. (A card, row, or element configuaration must be provided)                                                                                       |
+| style     | object | **Optional** | Style configuration.                                                                                                                                                   |
 
 ### Available variables for templating
 
@@ -185,20 +185,30 @@ type: 'custom:config-template-card'
         name: '${ setTempMessage("House: ", currentTemp) }'
 ````
 
-## Dashboard wide variables
+## Dashboard / view wide variables
 
-If you need to use the same variable in multiple cards, then instead of defining it in each card's `variables` you can do that once for the entire dashboard.
+If you need to use the same variable in multiple cards, then instead of defining it in each card's `variables` you can do that once for the entire dashboard or only individual views. In addition you can also define dashboard or view wide entities instead of adding them to each card's `entities`.
 
 ```yaml
 title: My dashboard
 
 config_template_card_vars:
   - states['sensor.light'].state
+config_template_card_entities:
+  - sensor.light
 
 views:
+  - title: My view
+
+    config_template_card_vars:
+      - states['sensor.otherlight'].state
+    config_template_card_entities:
+      - sensor.otherlight
+
+    cards:
 ```
 
-Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`. In the mixed mode, `vars` have array indices and as well as variable names.
+Both arrays and objects are supported, just like in card's local variables. It is allowed to mix the two types, i.e. use an array in dashboard / view variables and an object in card variables, or the other way around. If both definitions are arrays, then dashboard variables are put first in `vars`, next view variables and finally local ones. In the mixed mode, `vars` have array indices and as well as variable names.
 
 ### Note: All templates must be enclosed by `${}`
 

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -43,7 +43,7 @@ export class ConfigTemplateCard extends LitElement {
       throw new Error('No element type defined');
     }
 
-    if (!config.entities) {
+    if (this.getLovelacePanelEntities().length == 0 && this.getLovelaceViewEntities().length == 0 && !config.entities) {
       throw new Error('No entities defined');
     }
 
@@ -52,25 +52,63 @@ export class ConfigTemplateCard extends LitElement {
     void this.loadCardHelpers();
   }
 
-  private getLovelacePanel(): any {
+  private getLovelace(): any {
     const ha = document.querySelector('home-assistant');
     if (ha?.shadowRoot) {
       const haMain = ha.shadowRoot.querySelector('home-assistant-main');
       if (haMain?.shadowRoot) {
-        return haMain.shadowRoot.querySelector('ha-panel-lovelace');
+        const haPanel = haMain.shadowRoot.querySelector('ha-panel-lovelace');
+        if (haPanel?.shadowRoot) {
+          const huiRoot : any = haPanel.shadowRoot.querySelector('hui-root');
+          if (huiRoot) {
+            const ll = huiRoot.lovelace;
+            ll.current_view = huiRoot.___curView;
+            return ll;
+          }
+        }
       }
     }
     return null;
   }
 
-  private getLovelaceConfig(): any {
-    const panel = this.getLovelacePanel();
+  private getLovelacePanelConfig(): any {
+    const lovelace = this.getLovelace();
 
-    if (panel?.lovelace?.config?.config_template_card_vars) {
-      return panel.lovelace.config.config_template_card_vars;
+    if (lovelace?.config?.config_template_card_vars) {
+      return lovelace.config.config_template_card_vars;
     }
 
     return {};
+  }
+
+  private getLovelaceViewConfig(): any {
+    const lovelace = this.getLovelace();
+
+    if (lovelace?.config?.views[lovelace.current_view]?.config_template_card_vars) {
+      return lovelace.config.views[lovelace.current_view].config_template_card_vars;
+    }
+
+    return {};
+  }
+
+  private getLovelacePanelEntities() : any {
+    const lovelace = this.getLovelace();
+
+    if (lovelace?.config?.config_template_card_entities) {
+      return lovelace.config.config_template_card_entities;
+    }
+
+    return [];
+  }
+
+  private getLovelaceViewEntities() : any {
+    const lovelace = this.getLovelace();
+
+    if (lovelace?.current_view && lovelace?.config?.views[lovelace.current_view]?.config_template_card_entities) {
+      return lovelace.config.views[lovelace.current_view].config_template_card_entities;
+    }
+
+    return [];
   }
 
   protected shouldUpdate(changedProps: PropertyValues): boolean {
@@ -87,7 +125,25 @@ export class ConfigTemplateCard extends LitElement {
 
       if (oldHass) {
         this._evaluateVars();
-        for (const entity of this._evaluateStructure(structuredClone(this._config.entities))) {
+
+        const entities: string[] = [];
+        const panelEntities = this._evaluateStructure(structuredClone(this.getLovelacePanelEntities()));
+        if (Array.isArray(panelEntities)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          entities.push(...panelEntities);
+        }
+        const viewEntities = this._evaluateStructure(structuredClone(this.getLovelaceViewEntities()));
+        if (Array.isArray(viewEntities)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          entities.push(...viewEntities);
+        }
+        const localEntities = this._evaluateStructure(structuredClone(this._config.entities));
+        if (Array.isArray(localEntities)) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          entities.push(...localEntities);
+        }
+
+        for (const entity of entities) {
           if (this.hass && oldHass.states[entity] !== this.hass.states[entity]) {
             return true;
           }
@@ -224,22 +280,32 @@ export class ConfigTemplateCard extends LitElement {
     cv._evalInit += "var user = this._curVars.user;\n";
     cv._evalInit += "var vars = this._curVars.vars;\n";
 
+    const panelVars = this.getLovelacePanelConfig();
+    if (panelVars) {
+      if (Array.isArray(panelVars)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        arrayVars.push(...panelVars);
+      } else {
+        Object.assign(namedVars, panelVars);
+      }
+    }
+
+    const viewVars = this.getLovelaceViewConfig();
+    if (viewVars) {
+      if (Array.isArray(viewVars)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        arrayVars.push(...viewVars);
+      } else {
+        Object.assign(namedVars, viewVars);
+      }
+    }
+
     if (this._config?.variables) {
       if (Array.isArray(this._config.variables)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         arrayVars.push(...this._config.variables);
       } else {
         Object.assign(namedVars, this._config.variables);
-      }
-    }
-
-    const localVars = this.getLovelaceConfig();
-    if (localVars) {
-      if (Array.isArray(localVars)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        arrayVars.push(...localVars);
-      } else {
-        Object.assign(namedVars, localVars);
       }
     }
 


### PR DESCRIPTION
Hello there,

this project is something I did already some time ago and since I see that there is again activity in this repository I thought to propose it as an official feature.
In my use case I noticed that I reuse variables quite often in different cards which is what the dashboard wide variables feature was intended for, however I have multiple views that do not use the same variables, so having also the possibility of defining view wide variables is a feature I was really missing. I also thought since the entities list usually contains all the entities the variables are depending on, having dashboard / view wide variables implies also having dashboard / view wide  entities lists.
This PR adds both of these features. I am using this feature privately in my Home Assistant installation already for months and did not notice any bugs.

Best regards,
Triple-S