### PR TITLE
Load dashboard-level vars before others

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -224,22 +224,22 @@ export class ConfigTemplateCard extends LitElement {
     cv._evalInit += "var user = this._curVars.user;\n";
     cv._evalInit += "var vars = this._curVars.vars;\n";
 
+    const dashboardVars = this.getLovelaceConfig();
+    if (dashboardVars) {
+      if (Array.isArray(dashboardVars)) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        arrayVars.push(...dashboardVars);
+      } else {
+        Object.assign(namedVars, dashboardVars);
+      }
+    }
+
     if (this._config?.variables) {
       if (Array.isArray(this._config.variables)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         arrayVars.push(...this._config.variables);
       } else {
         Object.assign(namedVars, this._config.variables);
-      }
-    }
-
-    const localVars = this.getLovelaceConfig();
-    if (localVars) {
-      if (Array.isArray(localVars)) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        arrayVars.push(...localVars);
-      } else {
-        Object.assign(namedVars, localVars);
       }
     }
 
@@ -251,7 +251,13 @@ export class ConfigTemplateCard extends LitElement {
 
     for (const varName in namedVars) {
       let v = namedVars[varName];
-      if (isString(v)) { v = this._evalWithVars(v); }
+      if (isString(v)) { 
+         try { 
+           v = this._evalWithVars(v);
+         } catch { 
+           console.error('config-template-card - Failed _evalWithVars! *** varName: ' + varName + ' | namedVars[varName]: ' + namedVars[varName] + ' | v: ' + v); 
+         }  
+      }
       else { v = structuredClone(v); }
       vars[varName] = v;
       cv._evalInit += `var ${varName} = vars['${varName}'];\n`;


### PR DESCRIPTION
I don't have much time for this PR, but here's my best effort...

- I don't know if I am following project standards, coding standards... change anything you don't like.
- I don't particularly care if my name is on this code change; if you want to change anything and it is easier to close my PR and do a better one yourself with a it of copy-paste, go ahead, I don't mind

## Problem I am solving:

- config_template_card_vars define dashboard-level variables (I renamed localVars to reflect this).
- namedVars are lower-level, they are in individual cards inside the dashboards; so, it's natural that they might use the dashboard-level vars, not the other way around
- this means that the current order was breaking things and the card wouldn't load

## Logging eval problems to the console

Let's make this card more "transparent", easier to troubleshoot. I added a console log in case of error; and we should add more later.

## Example use case

I have a card that is included in more than one separate dashboard. During execution, it needs to know in which dashboard it is currently embedded in. So...

- mydashboard1.yaml
```yaml
title: Dash1

config_template_card_vars: 
  THEDASH: 
    name: one

views:
  - title: some view
    cards:
      - !include common.yaml
```


- mydashboard2.yaml
```yaml
title: Dash2

config_template_card_vars: 
  THEDASH: 
    name: two

views:
  - title: some view
    cards:
      - !include common.yaml
```

- common.yaml
```yaml
title: Common card
type: custom:config-template-card
variables:
  THETEXT: states['sensor.get_value_for_' + THEGROUP.name].state
entities:

...

```

This would fail very mysteriously and it took me hours to figure out why... it was because THEGROUP assignment was `eval`ed after
THETEXT, which is not the correct order.