### PR TITLE
fix: support template expressions embedded within strings (fixes #190)

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -369,6 +369,17 @@ export class ConfigTemplateCard extends LitElement {
       vars[varName] = newV;
     }
 
-    return evaluateExpression(template.substring(2, template.length - 1), 'template');
+    const isSingleExpression =
+      template.startsWith('${') &&
+      template.endsWith('}') &&
+      !template.slice(2, -1).includes('${');
+
+    if (isSingleExpression) {
+      // Pure ${expr}: strip wrapper and evaluate directly, preserving return type (number, object, etc.)
+      return evaluateExpression(template.substring(2, template.length - 1), 'template');
+    } else {
+      // Embedded template: evaluate as a JS template literal so ${...} inside is interpolated
+      return evaluateExpression('`' + template.replace(/`/g, '\\`') + '`', 'template');
+    }
   }
 }


### PR DESCRIPTION
Fixes #190 

Root Cause
  
  The bug is in _evaluateTemplate at line 372 of src/config-template-card.ts:

  return evaluateExpression(template.substring(2, template.length - 1), 'template');

  This unconditionally strips the first 2 characters (${) and the last character (}) from the
  template string, then evaluates what's left. This only works when the entire string is a pure
   expression, like ${span} or ${states["sensor.foo"].state}.

  When a user puts a template embedded within a larger string — like:
  - sensor.${best_model}_p_pv_forecast
  - EMHASS Forecasts (Model ${best_model})

  ...the slicing produces garbage:

  Template: EMHASS Forecasts (Model ${best_model})
  .substring(2, length-1): HASS Forecasts (Model ${best_model}
  new Function body: return (HASS Forecasts (Model linear));       
  Error: SyntaxError: Unexpected identifier 'Forecasts'
  ────────────────────────────────────────
  Template: sensor.${best_model}_p_pv_forecast
  .substring(2, length-1): nsor.${best_model}_p_pv_forecas
  new Function body: return (nsor.${best_model}_p_pv_forecas);
  Error: SyntaxError: Unexpected token '{'

  This feature (templates embedded within strings) was added in the old dev branch (referenced
  in PR #153) but was not ported into the 2.0 beta rewrite. The old master branch used eval()
  with a varDef string; the bot's fix correctly targeted that code. The beta branch uses new 
  Function() with named parameters — a fundamentally different mechanism.

  ---
  The Fix (beta branch)

  Replace the final return line in _evaluateTemplate with two-case logic:

  File: src/config-template-card.ts:372

  // CURRENT (broken):
```
  return evaluateExpression(template.substring(2, template.length - 1), 'template');
```

  // FIXED:
```
  const isSingleExpression =
    template.startsWith('${') &&
    template.endsWith('}') &&
    !template.slice(2, -1).includes('${');

  if (isSingleExpression) {
    // Pure ${expr}: strip wrapper and evaluate directly, preserving return type (number, 
  object, etc.)
    return evaluateExpression(template.substring(2, template.length - 1), 'template');
  } else {
    // Embedded template: evaluate as a JS template literal so ${...} inside is interpolated
    return evaluateExpression('`' + template.replace(/`/g, '\\`') + '`', 'template');
  }
```

  Why this works with new Function():

  evaluateExpression builds: new Function('hass', 'states', 'user', 'vars', ...namedVarNames, 
  `return (${expression});`)

  For the embedded case, expression becomes `sensor.${best_model}_p_pv_forecast` (with
  backticks), so the function body is:

  return (`sensor.${best_model}_p_pv_forecast`);

  best_model is a named parameter of the new Function call (because it's in namedVarNames,
  derived from the card's variables), so the template literal resolves it correctly to produce
  e.g. "sensor.linear_p_pv_forecast".

  The isSingleExpression check correctly distinguishes:
  - ${span} → single expression → return type preserved (could be number, object)
  - ${states["sensor.foo"].state} → single expression → evaluated as JS expression
  - sensor.${best_model}_pv_forecast → doesn't start with ${ → template literal
  - EMHASS Forecasts (Model ${best_model}) → doesn't start with ${ → template literal
  - ${foo} and ${bar} → two ${ occurrences → template literal → "val1 and val2"