### PR TITLE
fix: support multi-statement block templates

### DIFF
--- a/src/config-template-card.test.ts
+++ b/src/config-template-card.test.ts
@@ -332,6 +332,75 @@ describe('ConfigTemplateCard logic', () => {
     expect(value).toBe('GLOBAL-LOCAL');
   });
 
+  it('_evaluateTemplate evaluates multi-statement block templates with let declarations', () => {
+    card.hass = {
+      user: { name: 'Dev' },
+      states: {
+        'light.kitchen': { state: 'on' },
+        'light.bedroom': { state: 'off' },
+      },
+    } as never;
+
+    (card as unknown as { _config: unknown })._config = {
+      ...baseConfig,
+      variables: {
+        LIGHTS: "Object.keys(states).filter(k => k.startsWith('light'))",
+      },
+    };
+
+    const value = (
+      card as unknown as {
+        _evaluateTemplate: (template: string) => unknown;
+      }
+    )._evaluateTemplate('${\n  let result = [];\n  LIGHTS.forEach(e => result.push(e));\n  result;\n}');
+
+    expect(Array.isArray(value)).toBe(true);
+    expect(value).toContain('light.kitchen');
+    expect(value).toContain('light.bedroom');
+  });
+
+  it('shouldUpdate handles entities as a string template that evaluates to an array', () => {
+    (card as unknown as { _initialized: boolean })._initialized = true;
+    (card as unknown as { _config: unknown })._config = {
+      ...baseConfig,
+      entities: "${Object.keys(states).filter(k => k.startsWith('light'))}",
+      variables: {},
+    };
+
+    card.hass = {
+      states: {
+        'light.kitchen': {
+          state: 'on',
+          last_changed: '2',
+          last_updated: '2',
+        },
+      },
+    } as never;
+
+    const changedProps = new Map([
+      [
+        'hass',
+        {
+          states: {
+            'light.kitchen': {
+              state: 'off',
+              last_changed: '1',
+              last_updated: '1',
+            },
+          },
+        },
+      ],
+    ]);
+
+    const result = (
+      card as unknown as {
+        shouldUpdate: (props: Map<string, unknown>) => boolean;
+      }
+    ).shouldUpdate(changedProps);
+
+    expect(result).toBe(true);
+  });
+
   it('_evaluateTemplate logs context and rethrows when expression evaluation fails', () => {
     card.hass = {
       states: {},

--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -123,7 +123,16 @@ export class ConfigTemplateCard extends LitElement {
       const oldHass = changedProps.get('hass') as HomeAssistant | undefined;
 
       if (oldHass) {
-        for (const entityTemplate of this._config.entities) {
+        const rawEntities = this._config.entities;
+        const entityList: string[] =
+          typeof rawEntities === 'string'
+            ? (() => {
+                const r = this._evaluateTemplate(rawEntities);
+                return Array.isArray(r) ? (r as string[]) : [String(r)];
+              })()
+            : rawEntities;
+
+        for (const entityTemplate of entityList) {
           const currentEntityId = String(this._evaluateTemplate(entityTemplate));
           const oldEntityId = String(this._evaluateTemplate(entityTemplate, oldHass));
 
@@ -322,10 +331,20 @@ export class ConfigTemplateCard extends LitElement {
 
       const namedVarNames = Object.keys(namedVars);
       const namedVarValues = namedVarNames.map((name) => vars[name]);
-      const evaluator = new Function('hass', 'states', 'user', 'vars', ...namedVarNames, `return (${expression});`);
+      // Pass code as a parameter so eval runs in the function scope (named params visible),
+      // and returns the completion value — supports both single-expression and multi-statement blocks.
+      const evaluator = new Function(
+        'hass',
+        'states',
+        'user',
+        'vars',
+        ...namedVarNames,
+        '__code',
+        `return eval(__code);`,
+      );
 
       try {
-        return evaluator(hass, states, user, vars, ...namedVarValues);
+        return evaluator(hass, states, user, vars, ...namedVarValues, expression);
       } catch (error) {
         console.error('Failed to evaluate template expression', {
           template,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import type {
 
 export interface ConfigTemplateConfig {
   type: string;
-  entities: string[];
+  entities: string[] | string;
   variables?: string[] | { [key: string]: string };
   card?: LovelaceCardConfig;
   row?: EntitiesCardEntityConfig;


### PR DESCRIPTION
  Fixes #191 

  The bug is in _evaluateTemplate at line 372 of src/config-template-card.ts:

  return evaluateExpression(template.substring(2, template.length - 1), 'template');

  This unconditionally strips the first 2 characters (${) and the last character (}) from the
  template string, then evaluates what's left. This only works when the entire string is a pure
   expression, like ${span} or ${states["sensor.foo"].state}.

  When a user puts a template embedded within a larger string — like:
  - sensor.${best_model}_p_pv_forecast
  - EMHASS Forecasts (Model ${best_model})

  ...the slicing produces garbage:

  Template: EMHASS Forecasts (Model ${best_model})
  .substring(2, length-1): HASS Forecasts (Model ${best_model}
  new Function body: return (HASS Forecasts (Model linear));
  Error: SyntaxError: Unexpected identifier 'Forecasts'
  ────────────────────────────────────────
  Template: sensor.${best_model}_p_pv_forecast
  .substring(2, length-1): nsor.${best_model}_p_pv_forecas
  new Function body: return (nsor.${best_model}_p_pv_forecas);
  Error: SyntaxError: Unexpected token '{'

  This feature (templates embedded within strings) was added in the old dev branch (referenced
  in PR #153) but was not ported into the 2.0 beta rewrite. The old master branch used eval()
  with a varDef string; the bot's fix correctly targeted that code. The beta branch uses new
  Function() with named parameters — a fundamentally different mechanism.

  ---
  The Fix (beta branch)

  Replace the final return line in _evaluateTemplate with two-case logic:

  File: src/config-template-card.ts:372

  // CURRENT (broken):
  return evaluateExpression(template.substring(2, template.length - 1), 'template');

  // FIXED:
  const isSingleExpression =
    template.startsWith('${') && template.endsWith('}') && !template.slice(2, -1).includes('${');

  if (isSingleExpression) {
    // Pure ${expr}: strip wrapper and evaluate directly, preserving return type (number, object, etc.) return evaluateExpression(template.substring(2, template.length - 1), 'template'); } else { // Embedded template: evaluate as a JS template literal so ${...} inside is interpolated return evaluateExpression('`' + template.replace(/`/g, '\\`') + '`', 'template'); }

  Why this works with new Function():

  evaluateExpression builds: new Function('hass', 'states', 'user', 'vars', ...namedVarNames,
  `return (${expression});`)

  For the embedded case, expression becomes `sensor.${best_model}_p_pv_forecast` (with
  backticks), so the function body is:

  return (`sensor.${best_model}_p_pv_forecast`);

  best_model is a named parameter of the new Function call (because it's in namedVarNames,
  derived from the card's variables), so the template literal resolves it correctly to produce
  e.g. "sensor.linear_p_pv_forecast".

  The isSingleExpression check correctly distinguishes:
  - ${span} → single expression → return type preserved (could be number, object)
  - ${states["sensor.foo"].state} → single expression → evaluated as JS expression
  - sensor.${best_model}_pv_forecast → doesn't start with ${ → template literal
  - EMHASS Forecasts (Model ${best_model}) → doesn't start with ${ → template literal
  - ${foo} and ${bar} → two ${ occurrences → template literal → "val1 and val2"