### PR TITLE
fix: support multi-statement JS in named variables (#192)

### DIFF
--- a/src/config-template-card.ts
+++ b/src/config-template-card.ts
@@ -322,7 +322,7 @@ export class ConfigTemplateCard extends LitElement {
 
       const namedVarNames = Object.keys(namedVars);
       const namedVarValues = namedVarNames.map((name) => vars[name]);
-      const evaluator = new Function('hass', 'states', 'user', 'vars', ...namedVarNames, `return (${expression});`);
+      const evaluator = new Function('hass', 'states', 'user', 'vars', ...namedVarNames, `return eval(${JSON.stringify(expression)});`);
 
       try {
         return evaluator(hass, states, user, vars, ...namedVarValues);


### PR DESCRIPTION
## Summary

- Fixes `SyntaxError: Unexpected token 'const'` when a named variable contains multi-statement JS (e.g. `const c = "Use Me";\nc;`)
- Root cause: `new Function(..., 'return (expression)')` wraps the code as an expression, which is invalid syntax for statement-level code
- Fix: use `eval(JSON.stringify(expression))` inside the function body — `eval` returns the last evaluated value, handling multi-statement blocks correctly while still scoping `hass`, `states`, `user`, `vars`, and sibling variable names as before

Closes #192

## Test plan

- [ ] Verify the YAML example from the issue renders correctly: `${parent('xxx')}` → `"Please xxx"`, `${parent()}` → `"Please Use Me"`
- [ ] Confirm existing single-expression variables continue to work
- [ ] Confirm cross-variable references (a variable that calls another variable's function) still resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)